### PR TITLE
python-social-auth version update PR

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -37,7 +37,7 @@ pypandoc==0.9.7
 python-openid==2.2.5
 
 # social authentication/registration mechanizm
-python-social-auth==0.2.9
+python-social-auth==0.2.12
 
 pytz==2015.2
 requests==2.7.0

--- a/prod_requirements.txt
+++ b/prod_requirements.txt
@@ -26,7 +26,7 @@ pypandoc==0.9.7
 python-openid==2.2.5
 
 # social authentication/registration mechanizm
-python-social-auth==0.2.9
+python-social-auth==0.2.12
 
 pytz==2015.2
 requests==2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ pypandoc==0.9.7
 python-openid==2.2.5
 
 # social authentication/registration mechanizm
-python-social-auth==0.2.9
+python-social-auth==0.2.12
 
 pytz==2015.2
 requests==2.7.0


### PR DESCRIPTION
@dixon-che 

This PR contain version update for python-social-auth.

python-social-auth version was freezed to 0.2.9 because of [issue](https://github.com/omab/python-social-auth/issues/671).
This issue was fixed in [PR](https://github.com/omab/python-social-auth/pull/672) and have appeared in 0.2.12 version.
So now we can move to python-social-auth 0.2.12 version.

Task for this PR on [trello](https://trello.com/c/YR7uBK85/185-review-new-psa-0-2-12-version).
