### PR TITLE
Internal code review PR: pep8, pylint, code style and general refactor of fsm application

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,5 +49,5 @@ For a developer / test version to access social-auth, you will need to add the f
 Quality check
 -------------
 
-We can check code quality using `./check-quality.sh {pep8|pylint}` script.
+We can check code quality using ``./check-quality.sh {pep8|pylint} {lti|psa|fsm|ct|mysite|all}`` script.
 We encourage you to run this script before each commit.

--- a/check-quality.sh
+++ b/check-quality.sh
@@ -9,6 +9,7 @@ function run_pep8 {
     pep8 --config=$PEP8_CONF_PATH mysite/lti > $LOGS_PATH/pep8.log
     pep8 --config=$PEP8_CONF_PATH mysite/psa >> $LOGS_PATH/pep8.log
     pep8 --config=$PEP8_CONF_PATH mysite/ct >> $LOGS_PATH/pep8.log
+    pep8 --config=$PEP8_CONF_PATH mysite/fsm >> $LOGS_PATH/pep8.log
     pep8 --config=$PEP8_CONF_PATH mysite/mysite >> $LOGS_PATH/pep8.log
     
     cat $LOGS_PATH/pep8.log
@@ -20,7 +21,24 @@ function run_pylint {
     pylint --rcfile=$PYLINT_CONF_PATH mysite/lti > $LOGS_PATH/pylint.log
     pylint --rcfile=$PYLINT_CONF_PATH mysite/psa >> $LOGS_PATH/pylint.log
     pylint --rcfile=$PYLINT_CONF_PATH mysite/ct >> $LOGS_PATH/pylint.log
+    pylint --rcfile=$PYLINT_CONF_PATH mysite/fsm >> $LOGS_PATH/pylint.log
     pylint --rcfile=$PYLINT_CONF_PATH mysite/mysite >> $LOGS_PATH/pylint.log
+
+    cat $LOGS_PATH/pylint.log
+
+}
+
+function run_pep8_spec {
+
+    pep8 --config=$PEP8_CONF_PATH mysite/$1 > $LOGS_PATH/pep8.log
+    
+    cat $LOGS_PATH/pep8.log
+
+}
+
+function run_pylint_spec {
+
+    pylint --rcfile=$PYLINT_CONF_PATH mysite/$1 > $LOGS_PATH/pylint.log
 
     cat $LOGS_PATH/pylint.log
 
@@ -28,14 +46,26 @@ function run_pylint {
 
 case $1 in
     pep8)
-            run_pep8
+            if [ $2 = "all" ]; then
+                echo "Running pep8 on all apps."
+                run_pep8
+            else
+                echo "Running pep8 on $2 app."
+                run_pep8_spec $2
+            fi
         ;;
 
     pylint)
-            run_pylint
+            if [ $2 = "all" ]; then
+                echo "Running pylint on all apps."
+                run_pylint
+            else
+                echo "Running pylint on $2 app."
+                run_pylint_spec $2
+            fi
         ;;
 
     *)
-        echo "Usage: $0 {pep8|pylint}"
+        echo "Usage: $0 {pep8|pylint} {lti|psa|fsm|ct|mysite|all}"
         exit 1
 esac

--- a/mysite/ct/fsm_plugin/randomtrial.py
+++ b/mysite/ct/fsm_plugin/randomtrial.py
@@ -30,7 +30,7 @@ class START(object):
         fsmStack.state.set_data_attr('unit', unit)
         fsmStack.state.title = 'Studying: %s' % unit.title
         logName = 'rt_%s_%d' % (trialName, r)  # log for this treatment
-        fsmStack.state.activity = ActivityLog.get_or_create(logName)
+        fsmStack.state.activity, created = ActivityLog.objects.get_or_create(fsmName=logName)
         return node.get_path(fsmStack.state, request, **kwargs)
     next_edge = push_unit_fsm
     _unitAttr = 'testUnit'

--- a/mysite/fsm/fsm_plugin/testme.py
+++ b/mysite/fsm/fsm_plugin/testme.py
@@ -38,19 +38,23 @@ class START(object):
     path = 'ct:home'
     doLogging = True
     edges = (
-            dict(name='next', toNode='END', title='go go go'),
-        )
+        dict(name='next', toNode='END', title='go go go'),
+    )
 
 
 class MID(object):
     def get_help(self, node, state, request):
-        d = {'/ct/about/': 'here here!', '/ct/courses/1/': 'there there'}
-        return d.get(request.path, None)
+        path_help = {
+            '/ct/about/': 'here here!',
+            '/ct/courses/1/': 'there there'
+        }
+        return path_help.get(request.path, None)
+
     title = 'in the middle'
     path = 'ct:about'
     edges = (
-            dict(name='next', toNode='END', title='go go go'),
-        )
+        dict(name='next', toNode='END', title='go go go'),
+    )
 
 
 def get_specs():
@@ -74,7 +78,7 @@ class CALLER(object):
         return node
     edges = (
         dict(name='call', toNode='WAITER', title='start a sub-fsm'),
-        )
+    )
 
 
 class WAITER(object):
@@ -85,6 +89,8 @@ class WAITER(object):
         return self._path
 
     edges = (
-        dict(name='subfsmdone', toNode='SOMENODE',
-             title='continue after sub-fsm done'),
-        )
+        dict(
+            name='subfsmdone',
+            toNode='SOMENODE',
+            title='continue after sub-fsm done'),
+    )

--- a/mysite/fsm/fsmspec.py
+++ b/mysite/fsm/fsmspec.py
@@ -19,16 +19,19 @@ class FSMSpecification(object):
         for node in pluginNodes:  # expect list of node class objects
             modName = node.__module__
             name = node.__name__
-            d = dict(title=node.title, funcName=modName + '.' + name,
-                     description=getattr(node, '__doc__', None))
+            node_dict = dict(
+                title=node.title,
+                funcName=modName + '.' + name,
+                description=getattr(node, '__doc__', None)
+            )
             for attr in attrs:  # save node attributes
                 if hasattr(node, attr):
-                    d[attr] = getattr(node, attr)
-            nodeDict[name] = d
-            for e in getattr(node, 'edges', ()):
-                e = e.copy()  # prevent side effects
-                e['fromNode'] = name
-                edges.append(e)
+                    node_dict[attr] = getattr(node, attr)
+            nodeDict[name] = node_dict
+            for edge in getattr(node, 'edges', ()):
+                edge = edge.copy()  # prevent side effects
+                edge['fromNode'] = name
+                edges.append(edge)
         self.nodeData = nodeDict
         self.edgeData = edges
 
@@ -58,16 +61,16 @@ class CallerNode(object):
         return edge.toNode
 
 
-def deploy(modname, username):
+def deploy(mod_path, username):
     """
     Load FSM specifications found in the specified plugin module.
     """
     import importlib
-    mod = importlib.import_module(modname)
-    l = []
+    mod = importlib.import_module(mod_path)
+    fsm_list = []
     for fsmSpec in mod.get_specs():
-        l.append(fsmSpec.save_graph(username))
-    return l
+        fsm_list.append(fsmSpec.save_graph(username))
+    return fsm_list
 
 
 def deploy_all(username, ignore=('testme', '__init__'),
@@ -76,9 +79,9 @@ def deploy_all(username, ignore=('testme', '__init__'),
     Load all FSM specifications found via pattern but not ignore.
     """
     import glob
-    l = []
+    fsm_list = []
     for modpath in glob.glob(pattern):
-        mod = modpath[:-3].split('/')
-        if mod[-1] not in ignore:
-            l += deploy('.'.join(mod), username)
-    return l
+        splitted_path = modpath[:-3].split('/')
+        if splitted_path[-1] not in ignore:
+            fsm_list.extend(deploy('.'.join(splitted_path), username))
+    return fsm_list

--- a/mysite/fsm/models.py
+++ b/mysite/fsm/models.py
@@ -5,6 +5,8 @@ from django.db import models, transaction
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 
+from fsm.utils import get_plugin
+
 from ct.ct_util import reverse_path_args
 from ct.models import (
     Role,
@@ -22,51 +24,8 @@ from ct.models import (
 )
 
 
-def dump_json_id(o, name=None):
-    """
-    Produce tuple of form ("NAME_Response_id", o.pk).
-    """
-    l = []
-    if name:
-        l.append(name)
-    name = '_'.join(l + [o.__class__.__name__, 'id'])
-    return (name, o.pk)
-
-
-def dump_json_id_dict(d):
-    """
-    Get json representation of dict of db objects.
-    """
-    data = {}
-    for k, v in d.items():
-        if v.__class__.__name__ in klassNameDict:  # save db object id
-            name, pk = dump_json_id(v, k)
-            data[name] = pk
-        else:  # just copy literal value, assuming JSON can serialize it
-            data[k] = v
-    return json.dumps(data)
-
-
-def save_json_data(self, d=None, attr='data', doSave=True):
-    """
-    Save dict of object refs back to db blob field.
-    """
-    dictAttr = '_%s_dict' % attr
-    if d is None:  # save cached data
-        d = getattr(self, dictAttr)
-    else:  # save specified dict
-        setattr(self, dictAttr, d)  # cache on local object
-    if d:
-        s = dump_json_id_dict(d)
-    else:
-        s = None
-    setattr(self, attr, s)
-    if doSave:  # immediately write to db
-        self.save()
-
-
 # index of types that can be saved in json blobs
-klassNameDict = dict(
+KLASS_NAME_DICT = dict(
     Unit=Unit,
     Role=Role,
     Course=Course,
@@ -82,78 +41,106 @@ klassNameDict = dict(
 )
 
 
-def load_json_id(name, pk):
+class JSONBlobMixin(object):
     """
-    Get the specified object as (label, obj) tuple.
+    Mixin to dump/load data to/from JSON blob fields.
     """
-    l = name.split('_')
-    klassName = l[-2]
-    o = klassNameDict[klassName].objects.get(pk=pk)
-    return (l[0], o)
+    @staticmethod
+    def dump_json_id(obj, name=None):
+        """
+        Produce tuple of form ("NAME_Response_id", obj.pk).
+        """
+        _list = []
+        if name:
+            _list.append(name)
+        name = '_'.join(_list + [obj.__class__.__name__, 'id'])
+        return (name, obj.pk)
 
+    def dump_json_id_dict(self, state_data):
+        """
+        Get json representation of dict of db objects.
+        """
+        data = {}
+        for key, value in state_data.items():
+            if value.__class__.__name__ in KLASS_NAME_DICT:  # save db object id
+                name, pk = self.dump_json_id(value, key)
+                data[name] = pk
+            else:  # just copy literal value, assuming JSON can serialize it
+                data[key] = value
+        return json.dumps(data)
 
-def load_json_id_dict(s):
-    """
-    Get dict of db objects from json blob representation.
-    """
-    data = json.loads(s)
-    d = {}
-    for k, v in data.items():
-        if k.endswith('_id'):  # retrieve db object
-            name, obj = load_json_id(k, v)
-            d[name] = obj
-        else:  # just copy literal value
-            d[k] = v
-    return d
+    def save_json_data(self, state_data=None, attr='data', doSave=True):
+        """
+        Save dict of object refs back to db blob field.
+        """
+        dict_attr = '_%s_dict' % attr
+        if state_data is None:  # save cached data
+            state_data = getattr(self, dict_attr)
+        else:  # save specified dict
+            setattr(self, dict_attr, state_data)  # cache on local object
+        if state_data:
+            dumped_state_data = self.dump_json_id_dict(state_data)
+        else:
+            dumped_state_data = None
+        setattr(self, attr, dumped_state_data)
+        if doSave:  # immediately write to db
+            self.save()
 
+    @staticmethod
+    def load_json_id(name, pk):
+        """
+        Get the specified object as (label, obj) tuple.
+        """
+        splitted_name = name.split('_')
+        klass_name = splitted_name[-2]
+        obj = KLASS_NAME_DICT[klass_name].objects.get(pk=pk)
+        return (splitted_name[0], obj)
 
-def load_json_data(self, attr='data'):
-    """
-    Get dict of db objects from json blob field.
-    """
-    dictAttr = '_%s_dict' % attr
-    try:
-        return getattr(self, dictAttr)
-    except AttributeError:
-        pass
-    s = getattr(self, attr)
-    if s:
-        d = load_json_id_dict(s)
-    else:
-        d = {}
-    setattr(self, dictAttr, d)
-    return d
+    def load_json_id_dict(self, state_data):
+        """
+        Get dict of db objects from json blob representation.
+        """
+        data = json.loads(state_data)
+        obj_dict = {}
+        for key, value in data.items():
+            if key.endswith('_id'):  # retrieve db object
+                name, obj = self.load_json_id(key, value)
+                obj_dict[name] = obj
+            else:  # just copy literal value
+                obj_dict[key] = value
+        return obj_dict
 
+    def load_json_data(self, attr='data'):
+        """
+        Get dict of db objects from json blob field.
+        """
+        dict_attr = '_%s_dict' % attr
+        try:
+            return getattr(self, dict_attr)
+        except AttributeError:
+            pass
+        state_data = getattr(self, attr)
+        if state_data:
+            obj_dict = self.load_json_id_dict(state_data)
+        else:
+            obj_dict = {}
+        setattr(self, dict_attr, obj_dict)
+        return obj_dict
 
-def set_data_attr(self, attr, v):
-    """Set a single data attribute
+    def set_data_attr(self, attr, value):
+        """Set a single data attribute
 
-    Must later call save_json_data() to serialize.
-    """
-    d = self.load_json_data()
-    d[attr] = v
+        Must later call save_json_data() to serialize.
+        """
+        obj_dict = self.load_json_data()
+        obj_dict[attr] = value
 
-
-def get_data_attr(self, attr):
-    """
-    Get a single data attribute from json data.
-    """
-    d = self.load_json_data()
-    return d[attr]
-
-
-def get_plugin(funcName):
-    """
-    Import and call plugin func for this object.
-    """
-    import importlib
-    if not funcName:
-        raise ValueError('invalid call_plugin() with no funcName!')
-    i = funcName.rindex('.')
-    modName = funcName[:i]
-    funcName = funcName[i + 1:]
-    mod = importlib.import_module(modName)
-    return getattr(mod, funcName)
+    def get_data_attr(self, attr):
+        """
+        Get a single data attribute from json data.
+        """
+        obj_dict = self.load_json_data()
+        return obj_dict[attr]
 
 
 class FSM(models.Model):
@@ -172,8 +159,7 @@ class FSM(models.Model):
     addedBy = models.ForeignKey(User)
 
     @classmethod
-    def save_graph(klass, fsmData, nodeData, edgeData, username, fsmGroups=(),
-                   oldLabel='OLD'):
+    def save_graph(cls, fsmData, nodeData, edgeData, username, fsmGroups=(), oldLabel='OLD'):
         """Store FSM specification from node
 
         Store FSM specification from node, edge graph
@@ -189,42 +175,42 @@ class FSM(models.Model):
         oldName = name + oldLabel
         with transaction.atomic():  # rollback if db error occurs
             try:  # delete nameOLD FSM if any
-                old = klass.objects.get(name=oldName)
-            except klass.DoesNotExist:
+                old = cls.objects.get(name=oldName)
+            except cls.DoesNotExist:
                 pass
             else:
                 old.delete()
             try:  # rename current to nameOLD
-                old = klass.objects.get(name=name)
-            except klass.DoesNotExist:
+                old = cls.objects.get(name=name)
+            except cls.DoesNotExist:
                 pass
             else:
                 old.name = oldName
                 old.save()
-                for g in old.fsmgroup_set.all():
-                    g.delete()
+                for group in old.fsmgroup_set.all():
+                    group.delete()
                 # old.fsmgroup_set.clear() # RelatedManager has no attribute clear
-            f = klass(addedBy=user, **fsmData)  # create new FSM
-            f.save()
+            fsm = cls(addedBy=user, **fsmData)  # create new FSM
+            fsm.save()
             for groupName in fsmGroups:  # register in specified groups
-                f.fsmgroup_set.create(group=groupName)
+                fsm.fsmgroup_set.create(group=groupName)
             nodes = {}
             for name, nodeDict in nodeData.items():  # save nodes
-                node = FSMNode(name=name, fsm=f, addedBy=user, **nodeDict)
+                node = FSMNode(name=name, fsm=fsm, addedBy=user, **nodeDict)
                 if node.funcName:  # make sure plugin imports successfully
                     get_plugin(node.funcName)
                 node.save()
                 nodes[name] = node
                 if name == 'START':
-                    f.startNode = node
-                    f.save()
+                    fsm.startNode = node
+                    fsm.save()
             for edgeDict in edgeData:  # save edges
                 edgeDict = edgeDict.copy()  # don't modify input dict!
                 edgeDict['fromNode'] = nodes[edgeDict['fromNode']]
                 edgeDict['toNode'] = nodes[edgeDict['toNode']]
-                e = FSMEdge(addedBy=user, **edgeDict)
-                e.save()
-        return f
+                edge = FSMEdge(addedBy=user, **edgeDict)
+                edge.save()
+        return fsm
 
     def get_node(self, name):
         """
@@ -259,7 +245,7 @@ class PluginDescriptor(object):
         raise AttributeError('read only attribute!')
 
 
-class FSMNode(models.Model):
+class FSMNode(JSONBlobMixin, models.Model):
     """
     Stores one node of an FSM state-graph.
     """
@@ -274,10 +260,6 @@ class FSMNode(models.Model):
     addedBy = models.ForeignKey(User)
     funcName = models.CharField(max_length=200, null=True)
     doLogging = models.BooleanField(default=False)
-    load_json_data = load_json_data
-    save_json_data = save_json_data
-    get_data_attr = get_data_attr
-    set_data_attr = set_data_attr
     _plugin = PluginDescriptor()  # provide access to plugin code if any
 
     def event(self, fsmStack, request, eventName, **kwargs):
@@ -294,8 +276,7 @@ class FSMNode(models.Model):
         if eventName == 'start':  # default: just return our path
             return self.get_path(fsmStack.state, request, **kwargs)
         elif eventName:  # default: call transition with matching name
-            return fsmStack.state.transition(fsmStack, request, eventName,
-                                             **kwargs)
+            return fsmStack.state.transition(fsmStack, request, eventName, **kwargs)
 
     def get_path(self, state, request, defaultURL=None, **kwargs):
         """
@@ -344,7 +325,7 @@ class FSMStackResumeError(ValueError):
     pass
 
 
-class FSMEdge(models.Model):
+class FSMEdge(JSONBlobMixin, models.Model):
     """
     Stores one edge of an FSM state-graph.
     """
@@ -359,10 +340,6 @@ class FSMEdge(models.Model):
     atime = models.DateTimeField('time submitted', default=timezone.now)
     addedBy = models.ForeignKey(User)
     _funcDict = {}
-    load_json_data = load_json_data
-    save_json_data = save_json_data
-    get_data_attr = get_data_attr
-    set_data_attr = set_data_attr
 
     def transition(self, fsmStack, request, **kwargs):
         """
@@ -376,7 +353,7 @@ class FSMEdge(models.Model):
             return func(self, fsmStack, request, **kwargs)
 
 
-class FSMState(models.Model):
+class FSMState(JSONBlobMixin, models.Model):
     """
     Stores current state of a running FSM instance.
     """
@@ -397,19 +374,15 @@ class FSMState(models.Model):
     atime = models.DateTimeField('time started', default=timezone.now)
     activity = models.ForeignKey('ActivityLog', null=True)
     activityEvent = models.ForeignKey('ActivityEvent', null=True)
-    load_json_data = load_json_data
-    save_json_data = save_json_data
-    get_data_attr = get_data_attr
-    set_data_attr = set_data_attr
 
     def get_all_state_data(self):
         """
         Get dict of all our state data including unitLesson.
         """
-        d = self.load_json_data().copy()  # copy to avoid side-effects
+        objects_dict = self.load_json_data().copy()  # copy to avoid side-effects
         if self.unitLesson:
-            d['unitLesson'] = self.unitLesson
-        return d
+            objects_dict['unitLesson'] = self.unitLesson
+        return objects_dict
 
     def event(self, fsmStack, request, eventName, unitLesson=False, **kwargs):
         """
@@ -443,13 +416,13 @@ class FSMState(models.Model):
         Execute the specified transition and return destination URL.
         """
         try:
-            e = self.fsmNode.outgoing.get(name=name)
+            edge = self.fsmNode.outgoing.get(name=name)
         except FSMEdge.DoesNotExist:
             return None  # FSM does not handle this event, return control
         if self.activityEvent:  # record exit from this node
             self.activityEvent.log_exit_event(name)
             self.activityEvent = None
-        self.fsmNode = e.transition(fsmStack, request, **kwargs)
+        self.fsmNode = edge.transition(fsmStack, request, **kwargs)
         self.path = self.fsmNode.get_path(self, request, **kwargs)
         self.save()
         return self.path
@@ -485,11 +458,11 @@ class FSMState(models.Model):
         self.save()
 
     @classmethod
-    def find_live_sessions(klass, user):
+    def find_live_sessions(cls, user):
         """
         Get live sessions relevant to this user.
         """
-        return klass.objects.filter(
+        return cls.objects.filter(
             isLiveSession=True, activity__course__role__user=user
         )
 
@@ -504,31 +477,31 @@ class ActivityLog(models.Model):
     course = models.ForeignKey(Course, null=True)
 
     @classmethod
-    def get_or_create(klass, name):
+    def get_or_create(cls, name):
         """
         Get log with specified name if it exists, or create it.
         """
         try:
-            return klass.objects.get(fsmName=name)
-        except klass.DoesNotExist:
-            a = klass(fsmName=name)
-            a.save()
-            return a
+            return cls.objects.get(fsmName=name)
+        except cls.DoesNotExist:
+            activity_log = cls(fsmName=name)
+            activity_log.save()
+            return activity_log
 
     @classmethod
-    def log_node_entry(klass, fsmNode, user, unitLesson=None):
+    def log_node_entry(cls, fsmNode, user, unitLesson=None):
         """
         Record entry to this node, creating ActivityLog if needed.
         """
-        a = klass.get_or_create(fsmNode.fsm.name)
-        ae = ActivityEvent(
-            activity=a,
+        activity_log = cls.get_or_create(fsmNode.fsm.name)
+        activity_event = ActivityEvent(
+            activity=activity_log,
             user=user,
             nodeName=fsmNode.name,
             unitLesson=unitLesson
         )
-        ae.save()
-        return ae
+        activity_event.save()
+        return activity_event
 
 
 class ActivityEvent(models.Model):
@@ -544,6 +517,9 @@ class ActivityEvent(models.Model):
     exitEvent = models.CharField(max_length=64)
 
     def log_exit_event(self, eventName):
+        """
+        Log exit event.
+        """
         self.exitEvent = eventName
         self.endTime = timezone.now()
         self.save()

--- a/mysite/fsm/models.py
+++ b/mysite/fsm/models.py
@@ -477,23 +477,11 @@ class ActivityLog(models.Model):
     course = models.ForeignKey(Course, null=True)
 
     @classmethod
-    def get_or_create(cls, name):
-        """
-        Get log with specified name if it exists, or create it.
-        """
-        try:
-            return cls.objects.get(fsmName=name)
-        except cls.DoesNotExist:
-            activity_log = cls(fsmName=name)
-            activity_log.save()
-            return activity_log
-
-    @classmethod
     def log_node_entry(cls, fsmNode, user, unitLesson=None):
         """
         Record entry to this node, creating ActivityLog if needed.
         """
-        activity_log = cls.get_or_create(fsmNode.fsm.name)
+        activity_log, created = cls.objects.get_or_create(fsmName=fsmNode.fsm.name)
         activity_event = ActivityEvent(
             activity=activity_log,
             user=user,

--- a/mysite/fsm/utils.py
+++ b/mysite/fsm/utils.py
@@ -1,0 +1,17 @@
+"""
+Utils for FSM application.
+"""
+
+
+def get_plugin(funcName):
+    """
+    Import and call plugin func for this object.
+    """
+    import importlib
+    if not funcName:
+        raise ValueError('invalid call_plugin() with no funcName!')
+    i = funcName.rindex('.')
+    modName = funcName[:i]
+    funcName = funcName[i + 1:]
+    mod = importlib.import_module(modName)
+    return getattr(mod, funcName)

--- a/mysite/fsm/views.py
+++ b/mysite/fsm/views.py
@@ -65,7 +65,7 @@ def fsm_status(request):
             pageData.fsmStack.pop(request, eventName='exceptCancel')
             pageData.statusMessage = 'Activity canceled.'
         # follow this optional edge
-        elif pageData.fsmStack.state.fsmNode. outgoing.filter(name=task).count() > 0:
+        elif pageData.fsmStack.state.fsmNode.outgoing.filter(name=task).count() > 0:
             return pageData.fsm_redirect(request, task, vagueEvents=())
     if not pageData.fsmStack.state:  # search for unfinished activities
         unfinished = FSMState.objects.filter(user=request.user, children__isnull=True)


### PR DESCRIPTION
@dixon-che 
Main changes to `fsm` applcation:
- quality.sh: implement new syntax `./check-quality.sh {pep8|pylint} {lti|psa|fsm|ct|mysite|all}` to allow to check `pep8|pylint` issues separately for all applications
- mysite/fsm/models.py: add `JSONBlobMixin` to move project to django/python best practices of making a readable and supportable code
- mysite/fsm/utils.py: move `get_plugin` func to utils.py to separate logic that not belong to `django models`
- README.rst: update according to new check-quality syntax
- all `fsm` app: change code according to pep8 and our code stype. Resolve important pylint warnings.

Issue https://github.com/cjlee112/socraticqs2/issues/52
Task on [trello](https://trello.com/c/h6K1UkxM/168-fsm-refactor-pep8-pylint-add-jsonblobmixin).
