### PR TITLE
[Update documentation] PR for internal code review

### DIFF
--- a/doc/devintro.rst
+++ b/doc/devintro.rst
@@ -141,10 +141,6 @@ Steps to install PostgreSQL on Ubuntu machine:
    sudo -u postgres psql postgres
    postgres=# \password postgres
 
-* Finally we need to create database with desired name::
-
-    postgres=# CREATE DATABASE db_name ENCODING 'UTF8';
-
 * Now we can exit from PostgreSQL and start to configure our Django project to use created database::
 
     postgres=# \q
@@ -219,6 +215,25 @@ For installing PostgreSQL on Mac OS X please follow the official `instructions`_
 
 .. _instructions: http://www.postgresql.org/download/macosx/
 
+One of the prefered way to install PostreSQL is `Homebrew`_::
+
+    brew install postgres
+
+.. _Homebrew: http://brew.sh
+
+Postgres will be installed into ``/usr/local/var/postgres`` directory.
+
+Information about how to start Postgres you can find by following command::
+
+    brew info postgres
+
+By default Homebrew create postgres role with name as your mac username.
+
+So you need to set a password for this role::
+
+    psql postgres
+    \password your_username
+
 
 Configuring Django project for using PostgreSQL
 ...............................................
@@ -229,7 +244,7 @@ To configure project you need to copy ``mysite/settings/local_conf_example.py`` 
         'default': {
           'ENGINE': 'django.db.backends.postgresql_psycopg2',
           'NAME': 'db_name',
-          'USER': 'postgres',
+          'USER':  'your_username', (postgres for Ubuntu default configuration proccess)
           'PASSWORD': 'your_postgres_pass',
           'HOST': '',  # leave blank for localhost
           'PORT': '',  # leave blank for localhost
@@ -262,6 +277,17 @@ By default test suite is running on sqlite database to get a speed boost but you
 
     if 'test' in sys.argv or 'test_coverage' in sys.argv:
         DATABASES['default']['ENGINE'] = 'django.db.backends.sqlite3'
+
+
+.. warning::
+   
+    For Mac developer if you see ``ValueError: unknown locale: UTF-8`` do the following::
+
+        export LC_ALL=en_US.UTF-8
+        export LANG=en_US.UTF-8
+
+    Or add this lines to your ``~/.bash_profile``
+
 
 Running a test web server
 ...........................
@@ -527,3 +553,25 @@ You can flush (delete all data) from your database like this::
 You can then restore a particular snapshot like this::
 
   python manage.py loaddata dumpdata/mysnap.json
+
+
+Test project on PostgreSQL before making any PR
+:::::::::::::::::::::::::::::::::::::::::::::::
+
+You can develop project using sqlite db but before creating
+any PR you need to init PostgreSQL DB to ensure
+your code not breaking anything.
+
+* You can create and populate db with :doc:`fab`::
+
+    fab db.init
+
+This will create and populate db with fixture. Then deploy all FSMs.
+
+* Run all tests::
+
+    python manage.py test
+
+* Run test server and start Course from home page.
+* Go to Activity Page and restore Activity.
+* Go to Activity Page and cancel Activity.

--- a/doc/fab.rst
+++ b/doc/fab.rst
@@ -1,0 +1,129 @@
+Fabric deployment tool
+======================
+
+Introduction
+------------
+
+It provides a basic suite of operations for executing
+local or remote shell commands (normally or via sudo)
+and uploading/downloading files, as well as auxiliary
+functionality such as prompting the running user for
+input, or aborting execution.
+
+Typical use involves creating a Python module containing
+one or more functions, then executing them via the fab
+command-line tool.
+
+
+Configuration
+-------------
+
+To configure Fabric for Socraticqs2 project you need to 
+copy ``fab_settings.py.example`` file to ``fab_settings.py``::
+
+    cp fab_settings.py.example fab_settings.py
+
+Then you need to specify virtualenv name by setting
+``env.venv_name`` variable. By default it is setted to
+``_ve_socraticqs2``.
+
+
+Example fab_settings.py file::
+
+    """Settings for Fabric.
+
+    Params:
+
+    - env.venv_name: name of the current virtualenv
+    """
+    from fabric.api import env
+
+
+    env.venv_name = '_ve_socraticqs2'
+
+
+
+Fabric database tasks
+---------------------
+
+Database tasks are tasks that help to automate typical database actions.
+
+There are three DB tasks:
+
+* db.init
+* db.backup
+* db.restore
+
+To list all available tasks::
+
+  fab --list
+
+All tasks makes decision about DB engine given from Django settings and
+performs appropriate actions.
+
+Init DB task
+------------
+Usage::
+
+    fab db.init
+
+This task performs following actions:
+
+1. DROP database given from Django settings
+2. CREATE new database with name given from Django settings
+3. Apply all migrations
+4. Load fixture data
+5. Deploy FSMs
+
+Backup DB task
+--------------
+Usage::
+
+    fab db.backup[:custom_branch_name]
+
+This task performs following actions:
+
+  1. DROP database given from Django settings
+  2. CREATE new database with name given from Django settings
+  3. ``psql pg_dump > backup.postgres.custom_branch_name`` action
+     for PostgreSQL and ``cp mysite.db backup.sqlite.custom_branch_name``
+     action for SQLite DB.
+
+If ``custom_branch_name`` param is not presented task gets current
+git branch name and using it as a custom suffix for backup files.
+
+Restore DB task
+---------------
+Usage::
+
+    fab db.restore[:custom_branch_name]
+
+This task performs following actions:
+
+  1. DROP database given from Django settings
+  2. CREATE new database with name given from Django settings
+  3. ``psql < backup.postgres.custom_branch_name`` action for
+     PostgreSQL and ``cp backup.sqlite.custom_branch_name mysite.db``
+     action for SQLite DB.
+
+If ``custom_branch_name`` param is not presented task get current
+git branch name and using it as a suffix for backup files.
+
+If task can not find backup file it will list for you all backup files
+available with specific DB engine given from Django settings, e.g.::
+
+
+    $ fab db.restore:custom_branch_name
+    ...................................
+    [localhost] local: ls /path/to/proj/backups/backup.postgres.custom_branch_name
+    ls: cannot access /path/to/proj/backups/backup.postgres.custom_branch_name: No such file or directory
+    ================================
+    There is no requested backup file.
+    [localhost] local: ls backups
+    Below you can find available backup files:
+    backup.postgres.branch_1
+    backup.postgres.branch_2
+    backup.postgres.branch_3
+    ...................................
+
+    Done.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,6 +15,7 @@ Contents:
    fsm
    lti
    psa
+   fab
 
 Project Enhancement Proposals:
 

--- a/mysite/mysite/settings/local_conf_example.py
+++ b/mysite/mysite/settings/local_conf_example.py
@@ -1,5 +1,8 @@
 # coding: utf-8
 
+import sys
+
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
@@ -33,3 +36,6 @@ EMAIL_HOST_USER = ''
 EMAIL_HOST_PASSWORD = ''
 EMAIL_PORT = 587
 EMAIL_FROM = ''
+
+if 'test' in sys.argv or 'test_coverage' in sys.argv:
+    DATABASES['default']['ENGINE'] = 'django.db.backends.sqlite3'


### PR DESCRIPTION
@dixon-che 

Update documentation to describe Postgres and Fabric usage

Changes:
    - doc/devintro.rst: remove instructions about manual database and add Fabric tasks instructions
    - doc/fab.rst: describe Fabric usage
    - doc/devintro.rst: improve PostgreSQL installation and configuration section
    - local_conf_example.py: add ability to run unittests in sqlite

Issue https://github.com/cjlee112/socraticqs2/issues/54
Task on [trello](https://trello.com/c/WlaaLTMP/189-update-documentation-to-reflect-postgresql-usage).
